### PR TITLE
User Story 6: Submit An Application

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -22,8 +22,14 @@ class ApplicationsController < ApplicationController
     redirect_to "/applications/#{application.id}"
   end
 
+  def update
+    application = Application.find(params[:id])
+    application.update(application_params)
+    redirect_to "/applications/#{application.id}"
+  end
+
   private 
   def application_params
-    params.permit(:name, :street, :city, :state, :zip, :description, :status)
+    params.permit(:name, :street, :city, :state, :zip, :description, :status, :description_owner)
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -5,5 +5,10 @@ class Application < ApplicationRecord
   def pets?
     pets.present?
   end
+
+  def can_submit?
+    status == "In Progress" and
+    pets?
+  end
 end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,5 +1,9 @@
 class Application < ApplicationRecord
   has_many :application_pets
   has_many :pets, through: :application_pets
+
+  def pets?
+    pets.present?
+  end
 end
 

--- a/app/views/application/welcome.html.erb
+++ b/app/views/application/welcome.html.erb
@@ -1,4 +1,4 @@
 <h1>Adopt, don't shop!</h1>
 
-<p><%= link_to "Applications", "/applications" %></p>
+<p><%= link_to "View Applications", "/applications" %></p>
 

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -7,15 +7,11 @@
 <p><strong>Status: </strong><%= @application.status %></p>
 
 <h3>Pets</h3>
-<% if @application.pets? %>
 <ul>
   <% @application.pets.each do |pet| %>
     <li><%= link_to pet.name, "/pets/#{pet.id}" %></li>
   <% end %>
 </ul>
-<% else %>
-  <p>Please add a pet to this application.</p>
-<% end %>
 
 <% if @application.status == "In Progress" %>
   <h3>Add a Pet to this Application</h3>
@@ -29,5 +25,16 @@
   <% @search_results.each do |result| %>
     <%= result.name %>
   <% end %>
+<% end %>
 
+<% if @application.can_submit? %>
+  <div id="application_submission">
+    <h3>Submit Application</h3>
+    <%= form_with url: "/applications/#{@application.id}", method: :patch, local: true do |f| %>
+      <p>Please describe why you would make a good owner for these pet(s)</p>
+      <%= f.text_area :description_pets, size: "60x5" %><br>
+      <%= f.hidden_field :status, value: "Pending" %>
+      <%= f.submit "Submit Application" %>
+    <% end %>
+  </div>  
 <% end %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -14,17 +14,19 @@
 </ul>
 
 <% if @application.status == "In Progress" %>
-  <h3>Add a Pet to this Application</h3>
+  <div id="add-pets">
+    <h3>Add a Pet to this Application</h3>
 
-  <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
-    <%= f.label :search, "Pet Search" %>
-    <%= f.text_field :search %>
-    <%= f.submit "Submit" %>
-  <% end %>
+    <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
+      <%= f.label :search, "Pet Search" %>
+      <%= f.text_field :search %>
+      <%= f.submit "Submit" %>
+    <% end %>
 
-  <% @search_results.each do |result| %>
-    <%= result.name %>
-  <% end %>
+    <% @search_results.each do |result| %>
+      <%= result.name %>
+    <% end %>
+  </div>
 <% end %>
 
 <% if @application.can_submit? %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -8,11 +8,11 @@
 
 <h3>Pets</h3>
 <% if @application.pets? %>
-  <ul>
-    <% @application.pets.each do |pet| %>
-      <li><%= link_to pet.name, "/pets/#{pet.id}" %></li>
-    <% end %>
-  </ul>
+<ul>
+  <% @application.pets.each do |pet| %>
+    <li><%= link_to pet.name, "/pets/#{pet.id}" %></li>
+  <% end %>
+</ul>
 <% else %>
   <p>Please add a pet to this application.</p>
 <% end %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -32,7 +32,7 @@
     <h3>Submit Application</h3>
     <%= form_with url: "/applications/#{@application.id}", method: :patch, local: true do |f| %>
       <p>Please describe why you would make a good owner for these pet(s)</p>
-      <%= f.text_area :description_pets, size: "60x5" %><br>
+      <%= f.text_area :description_owner, size: "60x5" %><br>
       <%= f.hidden_field :status, value: "Pending" %>
       <%= f.submit "Submit Application" %>
     <% end %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -6,9 +6,15 @@
 <p><strong>Description: </strong><%= @application.description %></p>
 <p><strong>Status: </strong><%= @application.status %></p>
 
-<h3>Pets</h3><br>
-<% @application.pets.each do |pet| %>
-  <%= link_to pet.name, "/pets/#{pet.id}"  %>
+<h3>Pets</h3>
+<% if @application.pets? %>
+  <ul>
+    <% @application.pets.each do |pet| %>
+      <li><%= link_to pet.name, "/pets/#{pet.id}" %></li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>Please add a pet to this application.</p>
 <% end %>
 
 <% if @application.status == "In Progress" %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -1,10 +1,10 @@
 <h1>Name: <%= @application.name %></h1>
-<p>Street: <%= @application.street %></p>
-<p>City: <%= @application.city %></p>
-<p>State: <%= @application.state %></p>
-<p>Zip: <%= @application.zip %></p>
-<p>Description: <%= @application.description %></p>
-<p>Status: <%= @application.status %></p>
+<p><strong>Street: </strong><%= @application.street %></p>
+<p><strong>City: </strong><%= @application.city %></p>
+<p><strong>State: </strong><%= @application.state %></p>
+<p><strong>Zip: </strong><%= @application.zip %></p>
+<p><strong>Description: </strong><%= @application.description %></p>
+<p><strong>Status: </strong><%= @application.status %></p>
 
 <h3>Pets</h3><br>
 <% @application.pets.each do |pet| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,12 +16,15 @@
       <%= msg %>
     </div>
   <% end %>
-    <section>
-      <p><%= link_to "Pets", "/pets" %></p>
-      <p><%= link_to "Shelters", "/shelters" %></p>
-      <p><%= link_to "Veterinarians", "/veterinarians" %></p>
-      <p><%= link_to "Veterinary Offices", "/veterinary_offices" %></p>
-    </section>
+    <nav>
+      <%= link_to "Home", "/" %> |
+      <%= link_to "Applications", "/applications" %> |
+      <%= link_to "Pets", "/pets" %> |
+      <%= link_to "Shelters", "/shelters" %> |
+      <%= link_to "Veterinarians", "/veterinarians" %> |
+      <%= link_to "Veterinary Offices", "/veterinary_offices" %>
+    </nav>
+    <hr>
     <%= yield %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AdoptDontShop7</title>
+    <title>Adopt, Don't Shop (Alan, Paul, Ethan)</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -16,6 +16,7 @@
       <%= msg %>
     </div>
   <% end %>
+    <p><strong>Adopt, Don't Shop!</strong></p>
     <nav>
       <%= link_to "Home", "/" %> |
       <%= link_to "Applications", "/applications" %> |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,8 +39,9 @@ Rails.application.routes.draw do
 
   get "/applications", to: "applications#index"
   get "/applications/new", to: "applications#new"
-  post "/applications", to: "applications#create"
   get "/applications/:id", to: "applications#show"
+  post "/applications", to: "applications#create"
+  patch "/applications/:id", to: "applications#update"
 
   get "/admin/shelters", to: "admin_shelters#index"
 end

--- a/db/migrate/20230716041939_add_description_owner_to_applications.rb
+++ b/db/migrate/20230716041939_add_description_owner_to_applications.rb
@@ -1,0 +1,5 @@
+class AddDescriptionOwnerToApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :applications, :description_owner, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_13_223643) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_16_041939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,6 +33,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_13_223643) do
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "description_owner"
   end
 
   create_table "pets", force: :cascade do |t|

--- a/spec/features/applications/index_spec.rb
+++ b/spec/features/applications/index_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe "applications index page" do
       it "has a link to the applications show page" do
         visit "/"
     
-        expect(page).to have_link("Applications")
-        click_link("Applications")
+        expect(page).to have_link("View Applications")
+        click_link("View Applications")
         expect(page).to have_current_path("/applications")
         click_link(@application.name)
         expect(page).to have_content("Mr. Ape")

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -93,16 +93,26 @@ RSpec.describe "Application 'show' Page", type: :feature do
           visit "/applications/#{@application.id}"
 
           within("#application_submission") do
-            expect(page).to have_field(:description_pets, type: 
+            expect(page).to have_field(:description_owner, type: 
             "textarea")
             expect(page).to have_field(:status, type: :hidden)
           end
         end
 
         describe "When I fill in that input and click a button to submit the application" do
-          it "then I am taken back to the application's show page" do
+          before(:each) do
+            visit "/applications/#{@application.id}"
 
-          visit "/applications/#{@application.id}"
+            within("#application_submission") do
+              fill_in "description_owner", with: "I would make a good owner because I am really, really, really good with dogs"
+              click_button "Submit Application"
+            end            
+          end
+
+          it "then I am taken back to the application's show page" do
+            expect(current_path).to eq ("/applications/#{@application.id}")
+          end
+
 
           it "and I see indicator that the application is 'Pending'"
 

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe "Application 'show' Page", type: :feature do
   before(:each) do
-    @application = Application.create!(name: "Mr. Ape", street: "123 Turing Lane", city: "Boulder", state: "Colorado", zip: "80301", description: "I really want a dog because I love dogs", status: "In Progress")
-    @application_2 = Application.create!(name: "Paul", street: "1960 Penny Lane", city: "Bedfordshire", state: "England", zip: "48", description: "I still believe love is all you need.  I don't know a better message than that.", status: "Pending")
+    @application = Application.create!(name: "Mr. Ape", street: "123 Turing Lane", city: "Boulder", state: "CO", zip: "80301", description: "I really want a dog because I love dogs", status: "In Progress")
+    @application_2 = Application.create!(name: "Paul", street: "1960 Penny Lane", city: "Bedfordshire", state: "EN", zip: "48J47", description: "I still believe love is all you need.  I don't know a better message than that.", status: "Pending")
     
     @shelter = Shelter.create(name: "Aurora shelter", city: "Aurora, CO", foster_program: false, rank: 9)
 
@@ -75,14 +75,6 @@ RSpec.describe "Application 'show' Page", type: :feature do
       # ====START TESTS====
       describe "and I have added one or more pets to the application" do
         it "then I see a section to submit my application" do
-          petless = Application.create!(name: "Petless Tester", street: "123 Turing Lane", city: "Boulder", state: "Colorado", zip: "80301", description: "I do not want any pets and have not added any to my application", status: "In Progress")
-
-          # Make sure an in-progress application without pets DOES not have the "application-submission" div element
-          visit "/applications/#{petless.id}"
-          expect(petless.pets).to be_empty
-          expect(petless.status).to eq("In Progress")
-          expect(page).to_not have_selector("#application-submission")
-
           # Make sure an in-progress application with pets DOES have the "application-submission" div element
           visit "/applications/#{@application.id}"
           expect(@application.pets).to_not be_empty
@@ -131,6 +123,30 @@ RSpec.describe "Application 'show' Page", type: :feature do
         end
       end
       # ====END USER STORY 6 TESTS====
+
+      # User Story 7: No Pets on an Application 
+      # ====START TESTS====
+      describe "and I have not added any pets to the application" do
+        it "Then I do not see a section to submit my application" do
+          petless = Application.create!(name: "Petless Tester", street: "123 Turing Lane", city: "Boulder", state: "CO", zip: "80301", description: "I do not want any pets and have not added any to my application", status: "In Progress")
+
+          # Make sure an in-progress application without pets DOES not have the "application-submission" div element
+          visit "/applications/#{petless.id}"
+          expect(petless.pets).to be_empty
+          expect(petless.status).to eq("In Progress")
+          expect(page).to_not have_selector("#application-submission")
+
+          # #application-submission div shows up when you add a pet to the application
+          app_pet_3 = ApplicationPet.create!(application_id: petless.id, pet_id: @pet_1.id)
+          petless.reload
+          visit "/applications/#{petless.id}"
+
+          expect(petless.pets).to_not be_empty
+          expect(page).to have_selector("#application_submission") 
+        end       
+      end
+      # ====END USER STORY 7 TESTS====
+
     end
   end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -70,6 +70,23 @@ RSpec.describe "application show page", type: :feature do
           expect(page).to have_content(@pet_3.name)
         end
       end
+
+      # User Story 6: Submit an Applicaiton
+      describe "and I have added one or more pets to the application" do
+        it "then I see a section to submit my application"
+
+        it "I see an input in the submission section to enter why I would make a good owner for these pet(s)"
+
+        describe "when I fill in that input and click a button to submit the application" do
+          it "then I am taken back to the application's show page"
+
+          it "and I see indicator that the application is 'Pending'"
+
+          it "and I see all the pets that I want to adopt"
+
+          it "and I do not see a section to add more pets to this application"
+        end
+      end
     end
   end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -71,7 +71,8 @@ RSpec.describe "Application 'show' Page", type: :feature do
         end
       end
 
-      # User Story 6: Submit an Applicaiton
+      # User Story 6: Submit an Applicaiton 
+      # ====START TESTS====
       describe "and I have added one or more pets to the application" do
         it "then I see a section to submit my application" do
           petless = Application.create!(name: "Petless Tester", street: "123 Turing Lane", city: "Boulder", state: "Colorado", zip: "80301", description: "I do not want any pets and have not added any to my application", status: "In Progress")
@@ -106,6 +107,7 @@ RSpec.describe "Application 'show' Page", type: :feature do
             within("#application_submission") do
               fill_in "description_owner", with: "I would make a good owner because I am really, really, really good with dogs"
               click_button "Submit Application"
+              @application.reload
             end            
           end
 
@@ -113,14 +115,22 @@ RSpec.describe "Application 'show' Page", type: :feature do
             expect(current_path).to eq ("/applications/#{@application.id}")
           end
 
+          it "and I see indicator that the application is 'Pending'" do
+            expect(@application.status).to eq("Pending")
+            expect(page).to have_content("Status: Pending")
+          end
 
-          it "and I see indicator that the application is 'Pending'"
+          it "and I see all the pets that I want to adopt" do
+            expect(page).to have_content(@pet_1.name)
+            expect(page).to have_content(@pet_2.name)
+          end
 
-          it "and I see all the pets that I want to adopt"
-
-          it "and I do not see a section to add more pets to this application"
+          it "and I do not see a section to add more pets to this application" do
+            expect(page).to_not have_selector("#add-pets")
+          end
         end
       end
+      # ====END USER STORY 6 TESTS====
     end
   end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "application show page", type: :feature do
+RSpec.describe "Application 'show' Page", type: :feature do
   before(:each) do
     @application = Application.create!(name: "Mr. Ape", street: "123 Turing Lane", city: "Boulder", state: "Colorado", zip: "80301", description: "I really want a dog because I love dogs", status: "In Progress")
     @application_2 = Application.create!(name: "Paul", street: "1960 Penny Lane", city: "Bedfordshire", state: "England", zip: "48", description: "I still believe love is all you need.  I don't know a better message than that.", status: "Pending")
@@ -15,8 +15,8 @@ RSpec.describe "application show page", type: :feature do
     @app_pet_2 = ApplicationPet.create!(application_id: @application.id, pet_id: @pet_2.id)
   end
 
-  describe "as a visitor" do
-    describe "when visiting applicaiton show page" do
+  describe "As a visitor" do
+    describe "When visiting an application show page" do
       it "I can see applicant details" do
         visit "/applications/#{@application.id}"
 
@@ -46,8 +46,8 @@ RSpec.describe "application show page", type: :feature do
         expect(current_path).to eq("/pets/#{@pet_2.id}")
       end
 
-      describe "when the application has not been submitted" do
-        it "has a section that says 'Add a Pet to this Application'" do
+      describe "When the application has not been submitted" do
+        it "Has a section that says 'Add a Pet to this Application'" do
           visit "/applications/#{@application.id}"
           
           expect(page).to have_content("Add a Pet to this Application")
@@ -59,7 +59,7 @@ RSpec.describe "application show page", type: :feature do
           expect(page).to_not have_field("Pet Search")
         end
         
-        it "redirects_to the application show page after filling in Pet's name" do
+        it "Redirects_to the application show page after filling in Pet's name" do
           visit "/applications/#{@application.id}"
 
           expect(page).to_not have_content(@pet_3.name)
@@ -73,12 +73,36 @@ RSpec.describe "application show page", type: :feature do
 
       # User Story 6: Submit an Applicaiton
       describe "and I have added one or more pets to the application" do
-        it "then I see a section to submit my application"
+        it "then I see a section to submit my application" do
+          petless = Application.create!(name: "Petless Tester", street: "123 Turing Lane", city: "Boulder", state: "Colorado", zip: "80301", description: "I do not want any pets and have not added any to my application", status: "In Progress")
 
-        it "I see an input in the submission section to enter why I would make a good owner for these pet(s)"
+          # Make sure an in-progress application without pets DOES not have the "application-submission" div element
+          visit "/applications/#{petless.id}"
+          expect(petless.pets).to be_empty
+          expect(petless.status).to eq("In Progress")
+          expect(page).to_not have_selector("#application-submission")
 
-        describe "when I fill in that input and click a button to submit the application" do
-          it "then I am taken back to the application's show page"
+          # Make sure an in-progress application with pets DOES have the "application-submission" div element
+          visit "/applications/#{@application.id}"
+          expect(@application.pets).to_not be_empty
+          expect(@application.status).to eq("In Progress")
+          expect(page).to have_selector("#application_submission")
+        end
+
+        it "and I see an input in the submission section to enter why I would make a good owner for these pet(s)" do
+          visit "/applications/#{@application.id}"
+
+          within("#application_submission") do
+            expect(page).to have_field(:description_pets, type: 
+            "textarea")
+            expect(page).to have_field(:status, type: :hidden)
+          end
+        end
+
+        describe "When I fill in that input and click a button to submit the application" do
+          it "then I am taken back to the application's show page" do
+
+          visit "/applications/#{@application.id}"
 
           it "and I see indicator that the application is 'Pending'"
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -8,28 +8,43 @@ RSpec.describe Application, type: :model do
   end
 
   before(:each) do
-    @application_1 = Application.create!(name: "Mr. Ape", street: "123 Turing Lane", city: "Boulder", state: "Colorado", zip: "80301", description: "I really want a dog because I love dogs", status: "In Progress")
-    @application_2 = Application.create!(name: "Paul", street: "1960 Penny Lane", city: "Bedfordshire", state: "England", zip: "48", description: "I still believe love is all you need.  I don't know a better message than that.", status: "In Progress")
+    @mr_ape = Application.create!(name: "Mr. Ape", street: "123 Turing Lane", city: "Boulder", state: "Colorado", zip: "80301", description: "I really want a dog because I love dogs", status: "In Progress")
+    @paul = Application.create!(name: "Paul", street: "1960 Penny Lane", city: "Bedfordshire", state: "England", zip: "48", description: "I still believe love is all you need.  I don't know a better message than that.", status: "In Progress")
+    @penny_lane = Application.create(name: "Penny Lane", street: "555 McCartney", city: "Hollywood", state: "California", zip: "90210", description: "Strawberry Fields Forever", status: "Pending")
     
     @shelter = Shelter.create(name: "Aurora shelter", city: "Aurora, CO", foster_program: false, rank: 9)
 
     @pet_1 = Pet.create(adoptable: true, age: 1, breed: "sphynx", name: "Lucille Bald", shelter_id: @shelter.id)
     @pet_2 = Pet.create(adoptable: true, age: 3, breed: "doberman", name: "Lobster", shelter_id: @shelter.id)
 
-    @app_pet_1 = ApplicationPet.create!(application_id: @application_1.id, pet_id: @pet_1.id)
-    @app_pet_2 = ApplicationPet.create!(application_id: @application_1.id, pet_id: @pet_2.id)
+    @app_pet_1 = ApplicationPet.create!(application_id: @mr_ape.id, pet_id: @pet_1.id)
+    @app_pet_2 = ApplicationPet.create!(application_id: @mr_ape.id, pet_id: @pet_2.id)
   end
 
   describe "instance methods" do
     describe ".pets?" do
       it "returns a booleans if an application has any pets" do
-        expect(@application_1.pets?).to be true
-        expect(@application_2.pets?).to be false
+        expect(@mr_ape.pets?).to be true
+        expect(@paul.pets?).to be false
 
-        app2_pet = ApplicationPet.create!(application_id: @application_2.id, pet_id: @pet_1.id)
-        @application_2.reload
-        expect(@application_2.pets?).to be true
+        app2_pet = ApplicationPet.create!(application_id: @paul.id, pet_id: @pet_1.id)
+        @paul.reload
+        expect(@paul.pets?).to be true
       end
     end
+
+    describe ".can_submit?" do
+      it "returns a boolean if an application is 'In Progress' and has pets" do
+        expect(@mr_ape.can_submit?).to be true
+        expect(@paul.can_submit?).to be false
+        expect(@penny_lane.can_submit?).to be false
+
+        app2_pet = ApplicationPet.create!(application_id: @paul.id, pet_id: @pet_1.id)
+        @paul.reload
+        expect(@paul.can_submit?).to be true
+      end
+    end
+
   end
 end
+

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -6,4 +6,26 @@ RSpec.describe Application, type: :model do
     it { should have_many :application_pets }
     it { should have_many(:pets).through(:application_pets) }
   end
+
+  before(:each) do
+    @application_1 = Application.create!(name: "Mr. Ape", street: "123 Turing Lane", city: "Boulder", state: "Colorado", zip: "80301", description: "I really want a dog because I love dogs", status: "In Progress")
+    @application_2 = Application.create!(name: "Paul", street: "1960 Penny Lane", city: "Bedfordshire", state: "England", zip: "48", description: "I still believe love is all you need.  I don't know a better message than that.", status: "In Progress")
+    
+    @shelter = Shelter.create(name: "Aurora shelter", city: "Aurora, CO", foster_program: false, rank: 9)
+
+    @pet_1 = Pet.create(adoptable: true, age: 1, breed: "sphynx", name: "Lucille Bald", shelter_id: @shelter.id)
+    @pet_2 = Pet.create(adoptable: true, age: 3, breed: "doberman", name: "Lobster", shelter_id: @shelter.id)
+
+    @app_pet_1 = ApplicationPet.create!(application_id: @application_1.id, pet_id: @pet_1.id)
+    @app_pet_2 = ApplicationPet.create!(application_id: @application_1.id, pet_id: @pet_2.id)
+  end
+
+  describe "instance methods" do
+    describe ".pets?" do
+      it "returns a booleans if an application has any pets" do
+        expect(@application_1.pets?).to be true
+        expect(@application_2.pets?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe Application, type: :model do
       it "returns a booleans if an application has any pets" do
         expect(@application_1.pets?).to be true
         expect(@application_2.pets?).to be false
+
+        app2_pet = ApplicationPet.create!(application_id: @application_2.id, pet_id: @pet_1.id)
+        @application_2.reload
+        expect(@application_2.pets?).to be true
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,4 +91,5 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+config.formatter = :documentation
 end


### PR DESCRIPTION
This user story completes User Story 6: Submitting an Application AND User Story 7: No Pets on an Application.

I ended up changing the schema for the Application model, adding a `description_owner` column for the Applications table. See the migrations file. Along with this, I think it might be worthwhile to change the name of the previous `description` attribute to something like `description_home`, based off of their descriptions in the user story. My reasoning is that 
* User Story 2 asks for a form field for a `Description of why I would make a good home.`
* User Story 6 asks for `an input to enter why I would make a good owner for these pet(s).`
One asks why you would make a good **_home_** in general for a pet, and the other asks why you would be a good **_owner_** for **_specific_** pets.

In addition to the completion of User Stories 6+7, I also added some formatting
* I added a link and some nav bars to make pages easier to navigate (see pic)
![Screenshot 2023-07-16 at 2 23 19 AM](https://github.com/ethanrossblack/adopt-dont-shop-APE/assets/8324716/3b480bdb-2300-4dd9-b154-c8cebd86c9de)
* I also added some formatting for how pets are listed on the Show page. I put the pets into an unordered list (`<ul>`). See the code for more details
![Screenshot 2023-07-16 at 2 24 16 AM](https://github.com/ethanrossblack/adopt-dont-shop-APE/assets/8324716/b606bfaa-6923-405e-abfd-0a856c892c7b)
* I added a line to our `spec_helper` file to make the results look nicer in the terminal and like documentation
![Screenshot 2023-07-16 at 2 26 39 AM](https://github.com/ethanrossblack/adopt-dont-shop-APE/assets/8324716/f915e73e-3dc3-4feb-a4ec-c4a6d06627b4)


---
Things I should add to this PR
* Functionality where the `description_owner` appears on the show page after submission (and tests)

---
Closes #9
Closes #10